### PR TITLE
Fix Chartjs dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": {
     "angular": ">=1",
-    "chartjs" : ">=1.0.1"
+    "chartjs" : "1.0.1-2.1.6"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": {
     "angular": ">=1",
-    "chartjs" : "1.0.1-2.1.6"
+    "chartjs" : "<=2.1.6"
   }
 }


### PR DESCRIPTION
Starting with 2.2.0 Chartjs no longer supports bower
